### PR TITLE
Pre-release: oas2apigee cicd v2.0.0 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Within this repository you will find the **FIRST end-to-end** reference solution
 ## Key Features
 
 - Supports Apigee X / Hybrid.
+- Supports dynamic target endpoints.
+- Supports creation of property set files to extend the API proxy functionality.
 - Leverage fast API development.
 - Follows best practices.
 - Decoupled CI / CD.
@@ -106,9 +108,26 @@ An API developer will have to allocate single repository per API proxy where he 
   │   └── {oas_filename}.yaml
   ├── package-lock.json
   ├── package.json
+  ├── resources/
+  │   └── edge/
+  │       └── env/
+  │           ├──{env_1}/
+  │           │   └── properties
+  │           │       └── {property_set_filename}.properties
+  │           ├──{env_2}/
+  │           │   └── properties
+  │           │       └── {property_set_filename}.properties
+  │           ├──{env_3}
+  │           │     └── properties
+  │           │       └── {property_set_filename}.properties
+  │           │
+  │           └──.....
+  │
+  │
   └── test/
       └── integration/        // functional testing scripts
   </pre>
+  > :bulb: **Tip:** see resources/edge [multi-file config structure docs][apigee-config-mvn-folder-structure].
 
 ## The Why?
 
@@ -182,6 +201,8 @@ There are several important reasons to use the OpenAPI specification:
 
 - Existing Apigee X / Hybrid organization.
 - Existing Apigee environment(s) & environment group(s).
+- `resources/edge/env/{env_n}` must have the same name as your Apigee's environment(s), and you must follow the folder structure given otherwise the pipeline will **fail** on deployment.
+- `resources/edge/env/{env_n}/properties/{property_set_filename}.properties` must have this line `target_url = @TARGET_ENDPOINT/{proxy.pathsuffix}?{request.querystring}` which is crucial for the dynamic target endpoint functionality otherwise the pipeline will **fail** on deployment.
 - Two existing Azure DevOps pipelines with proper service connections:
   1. One for the build, suggested naming convention: `<REPO_NAME>-ci`.
   2. One for the release, suggested naming convention: `<REPO_NAME>-cd`.
@@ -236,7 +257,8 @@ git push -u my-repo feature/oas2apigee-cicd
       - `org`: Apigee's organization.
       - `proxyName`: Your API proxy name on Apigee organization **e.g** `abomis-v1`.
       - `oasFileName`: name of your OAS3.x file that you want to deploy **e.g** `abomis-v1.yaml`.
-      - `initialTargetEndpoint`: **OPTIONAL** Your API proxy target endpoint which will be attached to your API proxy bundle zip file artifact produced by your build pipeline. If not declared by default, the `initialTargetEndpoint` will be resolved to the `servers[0].url` base url within your OAS file.
+      - `propertySetFileName`: name of your property set file. **e.g** `abomis.properties`
+      - `propertySetName`: name of your property set resource on the environment. **e.g** `abomis`
       - `gcpServiceAccount`: paste the content of your your GCP service account key file as a **WHOLE**.
         > :warning: **Warning:** Make sure to check "Keep this value secret".
   - `<REPO_NAME>-{ENVIRONMENT}-env`:
@@ -423,8 +445,9 @@ Congratulations! you have deployed your first API proxy successfully. Now you ha
   <br />
 
   > :bulb: **Tip:** see [custom policies][apigeecli-custom-policies].
-- The solution doesn't support creating Apigee configuration resources.
+- The solution doesn't support creating Apigee configuration resources except for property sets.
 - The solution doesn't support mock API proxies (API proxies with no target endpoints).
+- It's planned from Google Cloud Apigee to enforce a limitation of 10 property set files per environment, you can read more [here][apigee-ps-limit].
 
 <br />
 
@@ -456,6 +479,7 @@ Shehab El-Deen Alalkamy
 [apigee-core-yaml-pipelines-templates]: https://github.com/ShehabEl-DeenAlalkamy/apigee-core-yaml-pipeline-templates
 [apigee-envgroups]: https://cloud.google.com/apigee/docs/api-platform/fundamentals/environments-overview
 [oas-github-info-field]: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#fixed-fields-1
+[apigee-config-mvn-folder-structure]: https://github.com/apigee/apigee-config-maven-plugin/tree/hybrid#multi-file-config
 [abomis-airports]: https://github.com/ShehabEl-DeenAlalkamy/abomis-airports
 [apigee-docs-understanding-apis-and-proxies]: https://cloud.google.com/apigee/docs/api-platform/fundamentals/understanding-apis-and-api-proxies
 [oas-github-v3.0]: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#openapi-specification
@@ -470,6 +494,7 @@ Shehab El-Deen Alalkamy
 [apigee-x-policies-spikearrest]: https://cloud.google.com/apigee/docs/api-platform/reference/policies/spike-arrest-policy
 [apigee-x-policies-quota]: https://cloud.google.com/apigee/docs/api-platform/reference/policies/quota-policy
 [apigeecli-custom-policies]: https://github.com/apigee/apigeecli#security-policies
+[apigee-ps-limit]: https://cloud.google.com/apigee/docs/api-platform/reference/limits#persistence:-cache,-kvm,-property-sets
 
 <!-- * Images * -->
 

--- a/cicd/build.yaml
+++ b/cicd/build.yaml
@@ -1,4 +1,3 @@
----
 trigger:
   branches:
     include:

--- a/cicd/build.yaml
+++ b/cicd/build.yaml
@@ -29,7 +29,10 @@ resources:
     - repository: apigee-core
       type: github
       name: ShehabEl-DeenAlalkamy/apigee-core-yaml-pipeline-templates
-      ref: refs/tags/v2.0.0-beta
+      # TODO: uncomment when work is done
+      # ref: refs/tags/v2.1.0-beta
+      # TODO: remove when development is done
+      ref: rel/framework-v2.1.0-beta
       endpoint: ShehabEl-DeenAlalkamy
 
 pool:

--- a/cicd/build.yaml
+++ b/cicd/build.yaml
@@ -28,10 +28,7 @@ resources:
     - repository: apigee-core
       type: github
       name: ShehabEl-DeenAlalkamy/apigee-core-yaml-pipeline-templates
-      # TODO: uncomment when work is done
-      # ref: refs/tags/v2.1.0-beta
-      # TODO: remove when development is done
-      ref: rel/framework-v2.1.0-beta
+      ref: refs/tags/v2.1.0-beta
       endpoint: ShehabEl-DeenAlalkamy
 
 pool:

--- a/cicd/release.yaml
+++ b/cicd/release.yaml
@@ -9,10 +9,7 @@ resources:
     - repository: apigee-core
       type: github
       name: ShehabEl-DeenAlalkamy/apigee-core-yaml-pipeline-templates
-      # TODO: uncomment when work is done
-      # ref: refs/tags/v2.1.0-beta
-      # TODO: remove when development is done
-      ref: rel/framework-v2.1.0-beta
+      ref: refs/tags/v2.1.0-beta
       endpoint: ShehabEl-DeenAlalkamy
   pipelines:
     - pipeline: abomis-ci

--- a/cicd/release.yaml
+++ b/cicd/release.yaml
@@ -17,10 +17,7 @@ resources:
       trigger:
         branches:
           include:
-            # TODO: uncomment when work is done
-            # - main
-            # TODO: remove when development is done
-            - release/oas2apigee-cicd-v2.0.0-beta
+            - main
 
 pool:
   vmImage: ubuntu-latest

--- a/cicd/release.yaml
+++ b/cicd/release.yaml
@@ -10,7 +10,10 @@ resources:
     - repository: apigee-core
       type: github
       name: ShehabEl-DeenAlalkamy/apigee-core-yaml-pipeline-templates
-      ref: refs/tags/v2.0.0-beta
+      # TODO: uncomment when work is done
+      # ref: refs/tags/v2.1.0-beta
+      # TODO: remove when development is done
+      ref: rel/framework-v2.1.0-beta
       endpoint: ShehabEl-DeenAlalkamy
   pipelines:
     - pipeline: abomis-ci
@@ -18,7 +21,10 @@ resources:
       trigger:
         branches:
           include:
-            - main
+            # TODO: uncomment when work is done
+            # - main
+            # TODO: remove when development is done
+            - release/oas2apigee-cicd-v2.0.0-beta
 
 pool:
   vmImage: ubuntu-latest

--- a/cicd/release.yaml
+++ b/cicd/release.yaml
@@ -1,4 +1,3 @@
----
 trigger: none
 
 pr: none

--- a/resources/edge/env/dev-env/properties/abomis.properties
+++ b/resources/edge/env/dev-env/properties/abomis.properties
@@ -1,0 +1,4 @@
+# ! CAUTION: don't modify, this line musts exist for solution functionality
+target_url = @TARGET_ENDPOINT/{proxy.pathsuffix}?{request.querystring}
+
+# you can add your additional key value pairs here

--- a/resources/edge/env/prd-env/properties/abomis.properties
+++ b/resources/edge/env/prd-env/properties/abomis.properties
@@ -1,0 +1,4 @@
+# ! CAUTION: don't modify, this line musts exist for solution functionality
+target_url = @TARGET_ENDPOINT/{proxy.pathsuffix}?{request.querystring}
+
+# you can add your additional key value pairs here

--- a/resources/edge/env/tst-env/properties/abomis.properties
+++ b/resources/edge/env/tst-env/properties/abomis.properties
@@ -1,0 +1,4 @@
+# ! CAUTION: don't modify, this line musts exist for solution functionality
+target_url = @TARGET_ENDPOINT/{proxy.pathsuffix}?{request.querystring}
+
+# you can add your additional key value pairs here


### PR DESCRIPTION
This marks the end of the first e2e reference solution to automating API proxies creation and deployment from OAS files in the entire world from functionality perspective.

This is a pre release to `oas2apigee cicd v2.0.0-beta`